### PR TITLE
Fix sidebar content padding issue

### DIFF
--- a/lib/collapsible_sidebar.dart
+++ b/lib/collapsible_sidebar.dart
@@ -337,7 +337,7 @@ class _CollapsibleSidebarState extends State<CollapsibleSidebar>
                     )
                   : Padding(
                       padding: EdgeInsets.only(
-                        left: widget.minWidth *
+                        left: widget.maxWidth *
                                 (widget.customContentPaddingLeft < 0
                                     ? 1.1
                                     : 1) +


### PR DESCRIPTION
If not collapsed, use max width instead of min width